### PR TITLE
Include git hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ By establishing these ideas as common practice we will:
 
 **8: Use [sensible defaults](sensible_defaults.md) unless you have a great reason not to**
 
-**9: Where practical, [include a git hash](include_git_hash.md) in
-the output of programs to promote reproducible analysis.**
+**9: Your work should be reproducible, it should be simple to replicate your work
+on someone else's machine. You may want to, [include a git hash](
+include_git_hash.md) in the output.**
 
 ## And some guidance on...
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ By establishing these ideas as common practice we will:
 
 **8: Use [sensible defaults](sensible_defaults.md) unless you have a great reason not to**
 
+**9: Where practical, [include a git hash](include_git_hash.md) in
+the output of programs to promote reproducible analysis.
+
 ## And some guidance on...
 
 **1: [Reviewing](reviewing_a_pull_request.md) a pull request**

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ By establishing these ideas as common practice we will:
 **8: Use [sensible defaults](sensible_defaults.md) unless you have a great reason not to**
 
 **9: Where practical, [include a git hash](include_git_hash.md) in
-the output of programs to promote reproducible analysis.
+the output of programs to promote reproducible analysis.**
 
 ## And some guidance on...
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ By establishing these ideas as common practice we will:
 
 **8: Use [sensible defaults](sensible_defaults.md) unless you have a great reason not to**
 
-**9: Your work should be reproducible, it should be simple to replicate your work
-on someone else's machine. You may want to, [include a git hash](
-include_git_hash.md) in the output.**
+**9: Analyses should be [simple and easy to reproduce](reproducibility.md) on another machine.**
 
 ## And some guidance on...
 

--- a/include_git_hash.md
+++ b/include_git_hash.md
@@ -1,0 +1,32 @@
+# Include a git hash
+
+If practical, the output of your code should include the git hash
+of the code that produced it. By doing so, the analysis should be
+more reproducible, there is no ambiguity about the specific code 
+that was used to generate it.
+
+## R
+You can access the git hash using either of the following code:
+snippets.
+```{r}
+library(git2r)
+
+repo <- repository(".")
+print(head(repo))
+```
+
+or
+
+```{r}
+print(system("git rev-parse --short HEAD", intern = TRUE))
+```
+
+## Python
+You can access the git hash using the following code:
+```import subprocess
+
+def get_git_revision_hash():
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+
+def get_git_revision_short_hash():
+    return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])```

--- a/reproducibility.md
+++ b/reproducibility.md
@@ -1,11 +1,13 @@
-# Include a git hash
+# Some tips on making your analyses simple to reproduce
+
+## Include a git hash
 
 If practical, the output of your code should include the git hash
 of the code that produced it. By doing so, the analysis should be
 more reproducible, there is no ambiguity about the specific code 
 that was used to generate it.
 
-## R
+### R
 You can access the git hash using either of the following code:
 snippets.
 ```{r}
@@ -21,7 +23,7 @@ or
 print(system("git rev-parse --short HEAD", intern = TRUE))
 ```
 
-## Python
+### Python
 You can access the git hash using the following code:
 ```import subprocess
 


### PR DESCRIPTION
Added a recommendation that the output of code should report the git hash so that analysis is more reproducible.

Added code snippets for python and R - I've nicked them from Stack Overflow, they look right, but should be tested.
I'm not sure if this is sufficiently detailed or linked - and would appreciate comments.